### PR TITLE
Add runtime config support for standalone shells

### DIFF
--- a/src/frontend/shells/account-standalone/index.html
+++ b/src/frontend/shells/account-standalone/index.html
@@ -5,6 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>My Account - Oluso</title>
+    <!-- Runtime config - generated at deploy time for production -->
+    <script src="/config.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/frontend/shells/account-standalone/package.json
+++ b/src/frontend/shells/account-standalone/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "build:cf": "node scripts/generate-config.js && tsc && vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview"
   },

--- a/src/frontend/shells/account-standalone/public/config.js
+++ b/src/frontend/shells/account-standalone/public/config.js
@@ -1,0 +1,7 @@
+// Oluso Account Runtime Configuration
+// This file is replaced at deploy time with environment-specific values
+// For local development, leave empty to use Vite env vars or defaults
+window.__OLUSO_CONFIG__ = {
+  // serverUrl: "https://api.example.com",
+  // apiUrl: "https://api.example.com",
+};

--- a/src/frontend/shells/account-standalone/scripts/generate-config.js
+++ b/src/frontend/shells/account-standalone/scripts/generate-config.js
@@ -1,0 +1,28 @@
+// Generate runtime config.js from environment variables
+// Used by Cloudflare Pages (and other CI/CD) at build time
+
+import { writeFileSync, mkdirSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const config = {
+  serverUrl: process.env.OLUSO_SERVER_URL || process.env.SERVER_URL,
+  apiUrl: process.env.OLUSO_API_URL || process.env.API_URL,
+};
+
+// Remove undefined values
+const cleanConfig = Object.fromEntries(
+  Object.entries(config).filter(([, v]) => v !== undefined)
+);
+
+const content = `// Generated at build time - ${new Date().toISOString()}
+window.__OLUSO_CONFIG__ = ${JSON.stringify(cleanConfig, null, 2)};
+`;
+
+const outputPath = join(__dirname, '../public/config.js');
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, content);
+
+console.log('Generated config.js:', cleanConfig);

--- a/src/frontend/shells/account-standalone/src/config.ts
+++ b/src/frontend/shells/account-standalone/src/config.ts
@@ -1,0 +1,28 @@
+// Runtime configuration for Oluso Account
+// In production, window.__OLUSO_CONFIG__ is set by /config.js (generated at deploy time)
+// In development, falls back to Vite env vars
+
+export interface OlusoConfig {
+  serverUrl: string;
+  apiUrl: string;
+}
+
+declare global {
+  interface Window {
+    __OLUSO_CONFIG__?: Partial<OlusoConfig>;
+  }
+}
+
+const runtimeConfig = window.__OLUSO_CONFIG__ ?? {};
+
+const serverUrl = runtimeConfig.serverUrl
+  ?? import.meta.env.VITE_SERVER_URL
+  ?? import.meta.env.VITE_OIDC_AUTHORITY
+  ?? 'http://localhost:5050';
+
+export const config: OlusoConfig = {
+  serverUrl,
+  apiUrl: runtimeConfig.apiUrl
+    ?? import.meta.env.VITE_API_BASE_URL
+    ?? serverUrl,
+};

--- a/src/frontend/shells/account-standalone/src/main.tsx
+++ b/src/frontend/shells/account-standalone/src/main.tsx
@@ -12,8 +12,11 @@ import { AccountApp, setApiBaseUrl } from '@oluso/account-ui';
 import { createFido2AccountPlugin } from '@oluso/fido2-ui';
 import { apiClient } from '@oluso/account-ui';
 
-// Configure API base URL from environment
-const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || import.meta.env.VITE_OIDC_AUTHORITY || 'http://localhost:5050';
+// Runtime config (supports Cloudflare Pages env vars)
+import { config } from './config';
+
+// Configure API base URL
+const apiBaseUrl = config.apiUrl;
 setApiBaseUrl(apiBaseUrl);
 
 // Create account plugins

--- a/src/frontend/shells/admin-standalone/index.html
+++ b/src/frontend/shells/admin-standalone/index.html
@@ -5,6 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Oluso Admin</title>
+    <!-- Runtime config - generated at deploy time for production -->
+    <script src="/config.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/frontend/shells/admin-standalone/package.json
+++ b/src/frontend/shells/admin-standalone/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "build:cf": "node scripts/generate-config.js && tsc && vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview"
   },

--- a/src/frontend/shells/admin-standalone/public/config.js
+++ b/src/frontend/shells/admin-standalone/public/config.js
@@ -1,0 +1,7 @@
+// Oluso Admin Runtime Configuration
+// This file is replaced at deploy time with environment-specific values
+// For local development, leave empty to use Vite env vars or defaults
+window.__OLUSO_CONFIG__ = {
+  // serverUrl: "https://api.example.com",
+  // apiUrl: "https://api.example.com/api/admin",
+};

--- a/src/frontend/shells/admin-standalone/scripts/generate-config.js
+++ b/src/frontend/shells/admin-standalone/scripts/generate-config.js
@@ -1,0 +1,28 @@
+// Generate runtime config.js from environment variables
+// Used by Cloudflare Pages (and other CI/CD) at build time
+
+import { writeFileSync, mkdirSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const config = {
+  serverUrl: process.env.OLUSO_SERVER_URL || process.env.SERVER_URL,
+  apiUrl: process.env.OLUSO_API_URL || process.env.API_URL,
+};
+
+// Remove undefined values
+const cleanConfig = Object.fromEntries(
+  Object.entries(config).filter(([, v]) => v !== undefined)
+);
+
+const content = `// Generated at build time - ${new Date().toISOString()}
+window.__OLUSO_CONFIG__ = ${JSON.stringify(cleanConfig, null, 2)};
+`;
+
+const outputPath = join(__dirname, '../public/config.js');
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, content);
+
+console.log('Generated config.js:', cleanConfig);

--- a/src/frontend/shells/admin-standalone/src/config.ts
+++ b/src/frontend/shells/admin-standalone/src/config.ts
@@ -1,0 +1,25 @@
+// Runtime configuration for Oluso Admin
+// In production, window.__OLUSO_CONFIG__ is set by /config.js (generated at deploy time)
+// In development, falls back to Vite env vars
+
+export interface OlusoConfig {
+  serverUrl: string;
+  apiUrl: string;
+}
+
+declare global {
+  interface Window {
+    __OLUSO_CONFIG__?: Partial<OlusoConfig>;
+  }
+}
+
+const runtimeConfig = window.__OLUSO_CONFIG__ ?? {};
+
+export const config: OlusoConfig = {
+  serverUrl: runtimeConfig.serverUrl
+    ?? import.meta.env.VITE_SERVER_URL
+    ?? 'http://localhost:5050',
+  apiUrl: runtimeConfig.apiUrl
+    ?? import.meta.env.VITE_API_URL
+    ?? `${runtimeConfig.serverUrl ?? import.meta.env.VITE_SERVER_URL ?? 'http://localhost:5050'}/api/admin`,
+};

--- a/src/frontend/shells/admin-standalone/src/main.tsx
+++ b/src/frontend/shells/admin-standalone/src/main.tsx
@@ -3,6 +3,9 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'react-hot-toast';
+
+// Import AdminUI base styles first, then shell overrides
+import '@oluso/admin-ui/styles';
 import './index.css';
 
 // Import the Admin UI library
@@ -13,10 +16,14 @@ import { createSamlPlugin } from '@oluso/saml-ui';
 import { createFido2Plugin } from '@oluso/fido2-ui';
 import { createScimPlugin } from '@oluso/scim-ui';
 import { createTelemetryPlugin } from '@oluso/telemetry-ui';
+import {createLdapPlugin} from "@oluso/ldap-ui";
 
-// Configure API base URL from environment
-const serverBaseUrl = import.meta.env.VITE_SERVER_URL || 'http://localhost:5050';
-const apiBaseUrl = import.meta.env.VITE_API_URL || `${serverBaseUrl}/api/admin`;
+// Runtime config (supports Cloudflare Pages env vars)
+import { config } from './config';
+
+// Configure API base URL
+const serverBaseUrl = config.serverUrl;
+const apiBaseUrl = config.apiUrl;
 setApiBaseUrl(apiBaseUrl);
 
 // Create enterprise plugins
@@ -25,6 +32,7 @@ const plugins = [
   createFido2Plugin({ apiClient }),
   createScimPlugin({ apiClient, serverBaseUrl }),
   createTelemetryPlugin({ apiClient }),
+  createLdapPlugin({ apiClient }),
 ];
 
 const queryClient = new QueryClient({

--- a/src/frontend/shells/admin-standalone/vite.config.ts
+++ b/src/frontend/shells/admin-standalone/vite.config.ts
@@ -7,12 +7,15 @@ export default defineConfig({
   resolve: {
     alias: {
       // Workspace packages - point to source during development
+      // Styles subpath must come before main package alias
+      '@oluso/admin-ui/styles': path.resolve(__dirname, '../../AdminUI/src/assets/styles/index.css'),
       '@oluso/admin-ui': path.resolve(__dirname, '../../AdminUI/src'),
       '@oluso/ui-core': path.resolve(__dirname, '../../ui-core/src'),
       '@oluso/fido2-ui': path.resolve(__dirname, '../../libs/fido2-ui'),
       '@oluso/saml-ui': path.resolve(__dirname, '../../libs/saml-ui'),
       '@oluso/scim-ui': path.resolve(__dirname, '../../libs/scim-ui'),
       '@oluso/telemetry-ui': path.resolve(__dirname, '../../libs/telemetry-ui'),
+      '@oluso/ldap-ui': path.resolve(__dirname, '../../libs/ldap-ui'),
     },
   },
   server: {


### PR DESCRIPTION
Introduces runtime configuration via config.js for both account-standalone and admin-standalone shells, enabling environment-specific settings at deploy time (e.g., Cloudflare Pages). 
Adds scripts to generate config.js, updates main entry points to use runtime config, and enhances admin shell with LDAP plugin and improved style imports.

## Summary by Sourcery

Introduce runtime-configurable API/server URLs for the account-standalone and admin-standalone shells using a shared config.js mechanism.

New Features:
- Add runtime configuration support for account-standalone and admin-standalone shells via a window-injected config.js file.
- Enable build-time generation of config.js from environment variables for both shells, suitable for platforms like Cloudflare Pages.
- Add LDAP plugin integration to the admin-standalone shell.

Enhancements:
- Update account and admin standalone shells to read API/server URLs from runtime config with sensible development fallbacks.
- Wire admin-standalone shell to use the Admin UI styles via a dedicated Vite alias.

Build:
- Add Cloudflare-oriented build scripts that generate runtime config.js before building the account and admin standalone shells.